### PR TITLE
Changed 'learning styles' to 'learning preferences'.

### DIFF
--- a/src/documents/index.html.md.handlebars
+++ b/src/documents/index.html.md.handlebars
@@ -10,8 +10,8 @@ Handlebars notation but still has a .handlebars file extension. If the
 generated when merging from docs-template.}}
 
 
-The Floe Inclusive Learning Design Handbook is a free Open Educational Resource (OER) designed to assist teachers, content creators, Web developers, and others in creating adaptable and personalizable educational resources that can accommodate a diversity of learning styles and individual needs.
-This is a work in a progress and we are constantly adding more content to this handbook. The information in this handbook is structured in the following sections:
+The Floe Inclusive Learning Design Handbook is a free Open Educational Resource (OER) designed to assist teachers, content creators, Web developers, and others in creating adaptable and personalizable educational resources that can accommodate a diversity of learning preferences and individual needs.
+This is a work in progress and we are constantly adding more content to this handbook. The information in this handbook is structured in the following sections:
 
 * [Introduction](introduction.html): Provides an introduction to the handbook and describes who can benefit from using it
 * [Perspectives](PerspectivesOverview.html): Contains articles that discuss the main issues related to education and inclusive learning


### PR DESCRIPTION
This change was a suggestion from Caren:
Do you think we should change the term learning "styles" to something like learning "preferences"? I'm thinking of the potential to conflate our meaning with the somewhat controversial Learning Styles framework that suggests an individual will have better learning outcomes within an identified "style" of learning: Visual, Auditory, Reading, or Kinesthetic. Research is suggesting "styles" are really more of a personal preference (someone likes pictures more than words), and that learning in an identified "style" doesn't necessarily influence better learning outcomes. I think having all styles of learning available within an environment and offering choice is more in line with an inclusive environment, therefore, words such as "preferences" might be more appropriate.