### PR TITLE
FLOE-552: Content pages without a category now omit sidebar

### DIFF
--- a/src/documents/css/docs-inclusive-learning.css.styl
+++ b/src/documents/css/docs-inclusive-learning.css.styl
@@ -88,11 +88,6 @@ uio-topics-background = #efefef;
 }
 
 .docs-inclusiveLearning {
-
-    &.no-category .docs-template-articleBody {
-        width: 100%;
-    }
-
     .docs-template-articleBody {
         h1, h2, h3, h4 {
             margin-top: 1rem;
@@ -101,6 +96,10 @@ uio-topics-background = #efefef;
         h4 {
             font-weight: bold;
         }
+    }
+
+    &.no-sidebar .docs-template-articleBody {
+        width: 100%;
     }
 
     .docs-template-logo {

--- a/src/documents/css/docs-inclusive-learning.css.styl
+++ b/src/documents/css/docs-inclusive-learning.css.styl
@@ -89,6 +89,10 @@ uio-topics-background = #efefef;
 
 .docs-inclusiveLearning {
 
+    &.no-category .docs-template-articleBody {
+        width: 100%;
+    }
+
     .docs-template-articleBody {
         h1, h2, h3, h4 {
             margin-top: 1rem;

--- a/src/documents/index.html.md.handlebars
+++ b/src/documents/index.html.md.handlebars
@@ -1,6 +1,7 @@
 ---
 title: Welcome to the Inclusive Learning Design Handbook
 layout: default
+noSidebar: true
 ---
 
 {{! Note: Aside from this comment, this file currently does not have any

--- a/src/documents/index.html.md.handlebars
+++ b/src/documents/index.html.md.handlebars
@@ -1,7 +1,6 @@
 ---
 title: Welcome to the Inclusive Learning Design Handbook
 layout: default
-category: Home
 ---
 
 {{! Note: Aside from this comment, this file currently does not have any

--- a/src/layouts/default.html.handlebars
+++ b/src/layouts/default.html.handlebars
@@ -21,13 +21,15 @@
         <script type="text/javascript" src="{{{getRelativeUrl '/lib/jqueryui/jquery-ui.min.js' document.url}}}"></script>
     </head>
 
-    <body class="docs-template docs-inclusiveLearning docs-core-sidebar-expanded">
+    <body class="docs-template docs-inclusiveLearning {{#if document.category}}docs-core-sidebar-expanded{{else}}no-category{{/if}}">
 
         <div class="container docs-template-container">
 
             <!-- Skip Link -->
             <nav id="skip" class="fl-inverted-color">
+                {{#if document.category}}
                 <a href="#topics" class="docs-template-skip-topics">Skip to Topics</a>
+                {{/if}}
                 <a href="#content" class="docs-template-skip-content">Skip to Content</a>
             </nav>
             <!-- END skip link -->
@@ -98,6 +100,7 @@
                 </div>
             </header>
 
+            {{#if document.category}}
             <div class="docs-corec-sidebar-bar ignore-for-TOC docs-template-topics-container small-8 medium-3 column">
                 <nav id="topics" class="docs-template-topics" tabindex="-1">
                     {{#each siteStructure}}
@@ -124,11 +127,14 @@
                     {{/each}}
                 </nav>
             </div>
+            {{/if}}
 
             <div class="docs-template-articleBody small-12 medium-8 column">
+                {{#if document.category}}
                 <div class="small-4 medium-1 column docs-template-topics-hideShow fl-inverted-color">
                     <a href="#" class="docs-corec-sidebar-toggle">Topics</a>
                 </div>
+                {{/if}}
 
                 <article id="content">
                     <h1>{{document.title}}</h1>

--- a/src/layouts/default.html.handlebars
+++ b/src/layouts/default.html.handlebars
@@ -21,13 +21,13 @@
         <script type="text/javascript" src="{{{getRelativeUrl '/lib/jqueryui/jquery-ui.min.js' document.url}}}"></script>
     </head>
 
-    <body class="docs-template docs-inclusiveLearning {{#if document.category}}docs-core-sidebar-expanded{{else}}no-category{{/if}}">
+    <body class="docs-template docs-inclusiveLearning docs-core-sidebar-expanded {{#if document.noSidebar}}no-sidebar{{/if}}">
 
         <div class="container docs-template-container">
 
             <!-- Skip Link -->
             <nav id="skip" class="fl-inverted-color">
-                {{#if document.category}}
+                {{#if document.noSidebar}}
                 <a href="#topics" class="docs-template-skip-topics">Skip to Topics</a>
                 {{/if}}
                 <a href="#content" class="docs-template-skip-content">Skip to Content</a>
@@ -100,7 +100,7 @@
                 </div>
             </header>
 
-            {{#if document.category}}
+            {{#unless document.noSidebar}}
             <div class="docs-corec-sidebar-bar ignore-for-TOC docs-template-topics-container small-8 medium-3 column">
                 <nav id="topics" class="docs-template-topics" tabindex="-1">
                     {{#each siteStructure}}
@@ -127,14 +127,14 @@
                     {{/each}}
                 </nav>
             </div>
-            {{/if}}
+            {{/unless}}
 
             <div class="docs-template-articleBody small-12 medium-8 column">
-                {{#if document.category}}
+                {{#unless document.noSidebar}}
                 <div class="small-4 medium-1 column docs-template-topics-hideShow fl-inverted-color">
                     <a href="#" class="docs-corec-sidebar-toggle">Topics</a>
                 </div>
-                {{/if}}
+                {{/unless}}
 
                 <article id="content">
                     <h1>{{document.title}}</h1>


### PR DESCRIPTION
If a content page does not have a Category front-matter (i.e. it is uncategorized), then do not display the sidebar. This prevents an issue where uncategorized content produces an empty sidebar.

This fix involves adding a condition to the default template to only render the sidebar if the category metadata is defined.