### PR TITLE
Update AccessibilityAssessmentTools.md

### DIFF
--- a/src/documents/AccessibilityAssessmentTools.md
+++ b/src/documents/AccessibilityAssessmentTools.md
@@ -7,7 +7,7 @@ category: Techniques
 
 ### Authoring
 * <a href="http://adod.idrc.ocad.ca/" rel="nofollow" target="_blank" class="link-external">How to make common word processing documents more accessible</a>
-* <a href="https://www.readability.com/addons"rel="nofollow" target="_blank" class="link-external">An example of a Mozilla browser plugin for removing clutter</a>
+* <a href="https://www.readability.com/addons" rel="nofollow" target="_blank" class="link-external">An example of a Mozilla browser plugin for removing clutter</a>
 
 ### Checking code
 * <a href="http://www.read-able.com/" rel="nofollow" target="_blank" class="link-external">Calculate the readability of a web page</a>


### PR DESCRIPTION
One of the links had an error that meant the whole code was showing up rather than just the text with the link. It was "An example of a Mozilla browser plugin ....". I added a space after the URL in the code and now it shows up correctly on output.